### PR TITLE
Allow PHP 7.3 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-configurable-sample-data-venia",
     "description": "N/A",
     "require": {
-        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0",
+        "php": "7.0.2|7.0.4|~7.0.6|~7.1.0|~7.2.0|~7.3.0",
         "magento/module-configurable-product": "*",
         "magento/module-sample-data": "*"
     },


### PR DESCRIPTION
Magento 2.3 is now expected to support PHP 7.3, but we have found in magento/pwa-studio#1550 that the Venia sample data modules won't install in that environment. This line in composer.json may be the culprit, at least for this module.

### Related
https://github.com/zetlen/module-tax-sample-data-venia/pull/1 is the same edit for the `module-tax-sample-data-venia` module.